### PR TITLE
Improve README persistence and add agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Guidelines for Coding Agents
+
+This repository contains a small WPF application located in the `RAMDrive Runner` directory.
+
+## Expectations
+
+- Keep all source files within the existing directory structure.
+- After making changes run:
+  
+  ```bash
+  dotnet build "RAMDrive Runner/RAMDrive Runner.csproj" -nologo
+  ```
+
+  If the build fails because the `dotnet` CLI is unavailable, mention that in the testing section of your pull request.
+- Update `README.md` when behavior or usage changes. The final line stating that the author relied on GPT-4 for WPF guidance should remain in the README.
+
+## Pull Request Guidelines
+
+- Summarize your changes clearly in the PR body.
+- Include the build output or note the failure as described above.
+- Leave the working tree clean with all changes committed.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,50 @@
 # RAMDrive-Runner
-I built this because I couldn't find a program that was as convenient as I wanted it to be.
 
-**This is dependent on ImDisk being installed and on the PATH**
+RAMDrive-Runner is a small WPF utility that copies a selected game folder to a temporary RAM disk and creates a junction so the game loads directly from memory.  It was written as a quick tool for personal use.
 
-This program creates a RAMDisk with your selected game's files so they load much faster while you are in the game.
+## How it works
 
-You select a folder where your games as stored (like a steam folder) and then you select the folder you want to create a RAM Drive for and you mount that drive.  
+1. The application enumerates the subfolders of a chosen source directory (by default Steam's `common` folder) and displays their sizes.
+2. When a folder is selected the RAM allocation slider is automatically set to a recommended size based on the folder size.
+3. Clicking **mount** performs the following tasks:
+   - Creates a RAM disk on drive **Z:** using [ImDisk](https://sourceforge.net/projects/imdisk-toolkit/).
+   - Formats the disk as NTFS.
+   - Copies the selected folder to the RAM disk.
+   - Renames the original folder to `<name>_RAMDisk` and creates a junction pointing to the RAM disk.
+4. The **unmount** button reverses the process by removing the junction, restoring the original folder and unmounting the RAM disk.
 
-The program will create a symbolic link in the name of the selected folder and point to the ram drive.  Unmounting cleans up after itself.
+Any PowerShell errors during these operations are written to `RAMRunnerErrorLog.txt` in the application directory.
 
-I have never written WPF before, I totally don't know what I am doing and i just used GPT4 to tell me what to code.
+## Requirements
+
+- Windows with the [.NET 6.0](https://dotnet.microsoft.com/download) runtime
+- [ImDisk](https://sourceforge.net/projects/imdisk-toolkit/) installed and available on the `PATH`
+
+## Building
+
+Open `RAMDrive Runner.sln` in Visual Studio 2022 or run:
+
+```bash
+dotnet build "RAMDrive Runner/RAMDrive Runner.csproj"
+```
+
+## Usage
+
+1. Launch **RAMDrive-Runner**.
+2. Click the source directory text box to browse to your game library.
+3. Select the folder you want to load into RAM.
+4. Adjust the RAM allocation slider if necessary (leave at least 8&nbsp;GB free for Windows).
+5. Press the **mount** button. A progress overlay will appear while files are copied.
+6. When finished, start your game normally. The data will be served from the RAM disk.
+7. After playing, press **unmount** to restore the original folder and free the RAM.
+
+## Screenshots
+
+Below are the three main states of the application.
+
+| Unloaded | Loading | Loaded |
+| --- | --- | --- |
+| ![Unloaded](ramdrive%20runner%20unloaded%20state.png) | ![Loading](ramdrive%20runner%20loading%20state.png) | ![Loaded](ramdrive%20runner%20loaded%20state.png) |
+
+I have never written WPF before and just used GPT-4 to tell me what to code.
+


### PR DESCRIPTION
## Summary
- ensure README keeps note about using GPT-4 for WPF help
- add AGENTS.md with repository guidelines

## Testing
- `dotnet build "RAMDrive Runner/RAMDrive Runner.csproj" -nologo` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683b06c4fde08329a379adf2977422d2